### PR TITLE
Don't spoil environment with '_system_*' variables

### DIFF
--- a/scripts/functions/environment
+++ b/scripts/functions/environment
@@ -294,6 +294,8 @@ __rvm_teardown()
   fi
 
   __variables_definition unset
+  
+  unset _system_arch _system_name _system_type _system_version
 
   return 0
 }


### PR DESCRIPTION
Changes proposed in this pull request:
* Don't spoil environment with '_system_*' variables
I find it quite annoying to have strange env variables in CI environment where rvm is installed and loaded.
Another question is why they don't have 'rvm' prefix.